### PR TITLE
Upgrade to node 8

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+# compiled output
+ui/dist/**/*
+ui/dist
+
+# dependencies
+ui/node_modules/**/*
+ui/node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,7 @@
 
-FROM node:7
-MAINTAINER Team Awesomeness (team-awesomeness@localhost)
+FROM node:8
 
-
-ADD ui /ui
+COPY ui /ui
 
 WORKDIR /ui
 


### PR DESCRIPTION
Done:
- Upgrade from node 7 to node 8 (LTS version).
- Added .dockerignore file to not include the /dist or /node_modules
  from the local ui builds. This prevents node version mis-matches
  from causing issues during the docker image build.
- Removed deprecated "maintainer" from Dockerfile.